### PR TITLE
Add minimize window command (:miw / :min)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/test_*
 !test/test_*.c
 !test/test_*.sh
 !test/test_*.h
+src/*.d

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,12 +8,18 @@
 - **`develop`** — active development, all work merges here first
 - **`fix/*`** or **`feat/*`** — short-lived branches off develop for PRs
 
+### Rules
+
+- **NEVER push to `develop`, `main`, or `release` without explicit user consent**
+- **NEVER create merge commits — always clean rebase for clean history**
+- **NEVER merge PRs that change app logic without user testing first**
+
 ### Making Changes
 
 1. Branch from `develop` (never from `main`)
 2. Make changes, build with `make clean && make`, run `make test`
 3. Push branch, create PR targeting `develop`
-4. Merge PR, update GitHub issue status
+4. Wait for user approval before merging
 
 ### Subagent PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,162 +1,43 @@
-# COFI - C/GTK Port of GOFI Window Switcher
+# COFI - C/GTK Window Switcher
 
-## Project Overview
+## Development Workflow
 
-COFI is a C/GTK port of the golang GOFI window switcher. Instead of using xterm+fzf for the UI, COFI provides a native GTK window with integrated search functionality.
+### Branch Structure
 
-## Core Architecture
+- **`main`** — stable releases, updated via PR from develop
+- **`develop`** — active development, all work merges here first
+- **`fix/*`** or **`feat/*`** — short-lived branches off develop for PRs
 
-### 1. Window Management (X11)
+### Making Changes
 
-- Direct X11 interaction using Xlib
-- EWMH (Extended Window Manager Hints) support
-- Monitor window list changes via _NET_CLIENT_LIST
-- Track active window via _NET_ACTIVE_WINDOW
-- Extract window properties:
-    - Title (_NET_WM_NAME, WM_NAME)
-    - Class/Instance (WM_CLASS)
-    - Type (_NET_WM_WINDOW_TYPE)
-    - Desktop (_NET_WM_DESKTOP)
-    - PID (_NET_WM_PID)
+1. Branch from `develop` (never from `main`)
+2. Make changes, build with `make clean && make`, run `make test`
+3. Push branch, create PR targeting `develop`
+4. Merge PR, update GitHub issue status
 
-### 2. History Management
+### Subagent PRs
 
-- Maintain MRU (Most Recently Used) window list
-- Move newly focused windows to front
-- Preserve order when windows close
-- Ignore self ("cofi" titled windows)
+When spawning agents for isolated work:
+- Always instruct them to branch from `develop`
+- Use `isolation: "worktree"` for parallel work
+- Agent creates branch `fix/<issue-slug>`, pushes, opens PR against `develop`
+- Review diff before merging — agents may branch from wrong base
 
-### 3. Window Ordering
+### Build & Run
 
-- Partition windows by type (Normal vs Special)
-- Normal windows appear first
-- **Alt-Tab Swap Logic**:
-    - The swap happens ONLY in the display layer, never in the data structures
-    - Data structures (windows, history, filtered) maintain true window order
-    - When displaying: swap positions 0 and 1 for visual display only
-    - When user selects entry 0 (first displayed), activate the window that's actually shown there
-    - This enables Alt-Tab-like behavior where pressing Enter immediately switches to previous window
-
-### 4. Multi-Stage Filtering
-
-Real-time search with intelligent scoring:
-
-1. **Word Boundary Matches** (score: 2000) - highest priority
-   - "comm" matches "Commodoro" (starts with "comm")
-   
-2. **Initials Matches** (score: 1900) - very high priority  
-   - "ddl" matches "Daniel Dario Lukic" (D-D-L initials)
-   
-3. **Subsequence Matches** (score: 1500) - high priority
-   - "th" matches "Thunderbird" (t-h in sequence)
-   
-4. **Fuzzy Matches** (variable score) - fallback
-   - Complex character matching with scoring
-
-Case-insensitive matching on window title, class name, and instance name.
-
-### 5. Display Format
-
-- 5-column layout:
-    - Desktop indicator [0-9] or [S] for sticky
-    - Instance name (20 chars)
-    - Window title (55 chars)  
-    - Class name (18 chars)
-    - Window ID (hex)
-- Selection indicator ">"
-- Monospace font for alignment
-- Bottom-up display (fzf-style) with first entry at bottom
-
-### 6. GTK UI
-
-- Borderless window
-- Stay on top
-- Skip taskbar
-- Center on screen
-- Text view for window list (top)
-- Entry widget for search (bottom)
-- Keyboard navigation:
-    - Up/Down: Navigate selection
-    - Enter: Activate selected window
-    - Escape: Cancel
-    - Real-time filtering as user types
-
-### 7. Window Activation
-
-- Direct X11 window activation using EWMH protocol
-- Switch to window's desktop first (_NET_CURRENT_DESKTOP)
-- Send activation message (_NET_ACTIVE_WINDOW)
-- Raise and map window (XMapRaised)
-- No external dependencies (replaced wmctrl)
-
-### 8. Event-Driven Updates
-
-- **PropertyNotify events**: Monitor root window for _NET_CLIENT_LIST and _NET_ACTIVE_WINDOW changes
-- **GIOChannel integration**: X11 file descriptor monitored via GLib main loop
-- **Real-time updates**: Window list refreshes automatically when windows are created/destroyed
-
-### 9. Single Instance Management
-
-- Uses D-Bus IPC for inter-process communication
-- Second instance calls ShowWindow method on first instance via D-Bus
-- Clean inter-process communication with automatic cleanup
-
-### 10. Harpoon-Style Window Assignment
-
-- Assign windows to number keys (Ctrl+number)
-- Direct switching (Alt+number)
-- Persistent storage in ~/.config/cofi.json
-- Automatic reassignment when windows close
-- Fuzzy matching for intelligent reassignment
-
-## Key Data Structures
-
-```c
-typedef struct {
-    Window id;
-    char title[MAX_TITLE_LEN];
-    char class_name[MAX_CLASS_LEN];
-    char instance[MAX_CLASS_LEN];
-    char type[16]; // "Normal" or "Special"
-    int desktop;
-    int pid;
-} WindowInfo;
-
-typedef struct {
-    GtkWidget *window;
-    GtkWidget *entry;
-    GtkWidget *textview;
-    GtkWidget *scrolled;
-    GtkTextBuffer *textbuffer;
-    
-    WindowInfo windows[MAX_WINDOWS];        // Raw window list from X11
-    WindowInfo history[MAX_WINDOWS];        // History-ordered windows
-    WindowInfo filtered[MAX_WINDOWS];       // Filtered and display-ready windows
-    int window_count;
-    int history_count;
-    int filtered_count;
-    int selected_index;
-    int active_window_id;                   // Currently active window
-    
-    Display *display;
-    HarpoonManager harpoon;
-} AppData;
+```bash
+make clean && make      # full rebuild (required after header changes)
+make test               # run all tests
+./restart.sh            # clean build + restart systemd service
+systemctl --user restart cofi  # restart without rebuild
+journalctl --user -u cofi -f   # tail logs
 ```
 
-## File Organization
+### Tracking
 
-- `src/main.c` - Application entry point and GTK setup
-- `src/x11_utils.c` - X11 window property extraction and activation
-- `src/window_list.c` - Window enumeration via EWMH
-- `src/history.c` - MRU ordering and Alt-Tab swap logic
-- `src/filter.c` - Multi-stage filtering with intelligent scoring
-- `src/display.c` - GTK display formatting and window activation
-- `src/x11_events.c` - Event-driven window list updates
-- `src/instance.c` - Single instance management
-- `src/harpoon.c` - Harpoon-style window assignments
-- `src/window_matcher.c` - Window matching logic
-- `src/match.c` - Fuzzy matching algorithms
-- `src/log.c` - Logging infrastructure
+- Issues and project board: https://github.com/DanielLukic/cofi/issues
+- Project: https://github.com/users/DanielLukic/projects/3
+- Status flow: Todo → In Progress → In Review → Done
 
 ## Coding Guidelines
 
@@ -165,13 +46,44 @@ typedef struct {
 3. **Work in small commit steps** with clear messages
 4. **Write tests for essential functionality**
 5. **Use logging instead of print statements**
-6. **Test with background processes** (`./cofi &`)
+6. **`make clean && make` after any header change** (no auto header deps yet)
 
-## Technical Features
+## Architecture Overview
 
-- **Zero external dependencies** for window activation
-- **Event-driven architecture** with no polling
-- **Intelligent fuzzy matching** with multi-stage scoring
-- **Memory efficient** with fixed-size arrays
-- **X11 EWMH compliant** for broad window manager support
-- **GTK3 native UI** with proper focus handling
+- **X11/EWMH** — direct Xlib for window management, no wmctrl
+- **GTK3** — native UI with borderless always-on-top window
+- **Event-driven** — PropertyNotify via GIOChannel, no polling
+- **Single instance** — XGrabKey failure guards against duplicates
+- **Daemon mode** — starts hidden, registers global hotkeys, waits
+- **Systemd** — `make install` sets up user service with auto-restart
+
+## Key Subsystems
+
+- **MRU history** — focus-tracking window order, partition by type/desktop
+- **Fuzzy search** — fzf-style scoring + initials + word boundary matching
+- **Harpoon slots** — 36 persistent window assignments (0-9, a-z)
+- **Workspace slots** — auto-numbered by screen position per workspace
+- **Command mode** — vim-style `:` commands with compact syntax
+- **Tiling** — half/quarter/third/grid positions, multi-monitor aware
+- **Hotkeys** — configurable global X11 grabs via hotkeys.json
+- **Config** — runtime-editable via `:set` or Config tab (Ctrl+T/Ctrl+E)
+
+## File Organization
+
+- `src/main.c` — entry point, GTK setup, key handlers, tab switching
+- `src/filter.c` — search/scoring pipeline, MRU vs native ordering
+- `src/display.c` — text formatting for all tabs
+- `src/config.c` — config load/save/apply, build_config_entries (single source of truth)
+- `src/command_mode.c` — command parsing, execution, all `:` commands
+- `src/workspace_slots.c` — per-workspace slot assignment and column/row sort
+- `src/hotkeys.c` — global XGrabKey registration and dispatch
+- `src/harpoon.c` — persistent window slot assignments
+- `src/history.c` — MRU ordering and partition_and_reorder
+- `src/x11_utils.c` — X11 property extraction and window activation
+- `src/x11_events.c` — event-driven window list updates
+- `src/window_list.c` — EWMH window enumeration
+- `src/slot_overlay.c` — numbered overlay indicators on windows
+- `src/window_highlight.c` — circle ripple effect on activation
+- `src/monitor_move.c` — window geometry and multi-monitor support
+- `src/tiling.c` — tiling positions and calculations
+- `src/log.c` — rxi/log.c logging library

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 CC = gcc
 CXX = g++
-CFLAGS = -Wall -Wextra -g -Wno-deprecated-declarations $(shell pkg-config --cflags gtk+-3.0 x11 gio-2.0)
+CFLAGS = -Wall -Wextra -g -Wno-deprecated-declarations -MMD -MP $(shell pkg-config --cflags gtk+-3.0 x11 gio-2.0)
 CXXFLAGS = $(CFLAGS) -std=c++11 -Iinclude
 LDFLAGS = $(shell pkg-config --libs gtk+-3.0 x11 gio-2.0) -lm -lXrandr -lXfixes -lXft -lstdc++
 
@@ -84,7 +84,7 @@ src/%.o: src/%.cpp
 
 # Clean build artifacts
 clean:
-	rm -f $(OBJECTS) $(TARGET)
+	rm -f $(OBJECTS) $(TARGET) src/*.d
 	rm -f test/test_command_parsing test/test_window_matcher
 
 
@@ -195,5 +195,7 @@ test_event_sequence: test/test_event_sequence.c src/harpoon.o src/window_matcher
 
 clean_tests:
 	rm -f test/test_* test/*.o
+
+-include $(wildcard src/*.d)
 
 .PHONY: all clean install uninstall debug run test build_tests clean_tests

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run: $(TARGET)
 	./$(TARGET)
 
 # Test targets
-test: test_window_matcher test_command_parsing test_config_roundtrip test_config_set test_hotkey_config test_fzf_algo test_named_window test_match_scoring test_command_aliases test_wildcard_match
+test: test_window_matcher test_command_parsing test_config_roundtrip test_config_set test_hotkey_config test_fzf_algo test_named_window test_match_scoring test_command_aliases test_wildcard_match test_parse_shortcut
 	cd test && ./run_tests.sh
 
 # Build command parsing test
@@ -168,6 +168,10 @@ test_command_aliases: test/test_command_aliases.c src/command_parser.o
 # Build wildcard match test
 test_wildcard_match: test/test_wildcard_match.c src/window_matcher.o src/log.o
 	$(CC) $(CFLAGS) -o test/test_wildcard_match test/test_wildcard_match.c src/window_matcher.o src/log.o $(LDFLAGS)
+
+# Build parse shortcut test
+test_parse_shortcut: test/test_parse_shortcut.c src/utils.o
+	$(CC) $(CFLAGS) -o test/test_parse_shortcut test/test_parse_shortcut.c src/utils.o $(LDFLAGS)
 
 # Quick test targets for development
 test_quick: src/match.o

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ run: $(TARGET)
 	./$(TARGET)
 
 # Test targets
-test: test_window_matcher test_command_parsing test_config_roundtrip test_config_set test_hotkey_config test_fzf_algo test_named_window test_match_scoring test_command_aliases test_wildcard_match test_parse_shortcut
+test: test_window_matcher test_command_parsing test_config_roundtrip test_config_set test_hotkey_config test_fzf_algo test_named_window test_match_scoring test_command_aliases test_wildcard_match test_parse_shortcut test_scrollbar
 	cd test && ./run_tests.sh
 
 # Build command parsing test
@@ -172,6 +172,10 @@ test_wildcard_match: test/test_wildcard_match.c src/window_matcher.o src/log.o
 # Build parse shortcut test
 test_parse_shortcut: test/test_parse_shortcut.c src/utils.o
 	$(CC) $(CFLAGS) -o test/test_parse_shortcut test/test_parse_shortcut.c src/utils.o $(LDFLAGS)
+
+# Build scrollbar overlay test (extracts scrollbar functions only)
+test_scrollbar: test/test_scrollbar.c
+	$(CC) $(CFLAGS) -DSCROLLBAR_TEST_STANDALONE -o test/test_scrollbar test/test_scrollbar.c $(LDFLAGS)
 
 # Quick test targets for development
 test_quick: src/match.o

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ Press `:` to enter command mode for advanced window management operations. Comma
 - `:sw` or `:swap-windows` - Swap two windows (positions and sizes)
 - `:cl` or `:close-window` or `:c` - Close selected window
 - `:mw` or `:maximize-window` or `:m` - Toggle maximize
+- `:miw` or `:min` or `:minimize-window` - Toggle minimize (restore if already minimized)
 - `:hm` or `:horizontal-maximize-window` - Toggle horizontal maximize
 - `:vm` or `:vertical-maximize-window` - Toggle vertical maximize
 

--- a/README.md
+++ b/README.md
@@ -200,16 +200,29 @@ Press `:` to enter command mode for advanced window management operations. Comma
 **Window Properties:**
 - `:sb` or `:skip-taskbar` - Toggle skip taskbar
 - `:at` or `:always-on-top` or `:aot` - Toggle always on top
+- `:ab` or `:always-below` - Toggle always below
 - `:ew` or `:every-workspace` - Toggle sticky (show on all workspaces)
 
 **Navigation:**
 - `:jw [N|dir]` or `:jump-workspace [N|dir]` or `:j [N|dir]` - Jump to workspace N or direction (h/j/k/l)
-  
+
   ![Jump to Workspace](doc/cofi-jump-workspace.png)
+- `:rw [N]` or `:rename-workspace` - Rename workspace N (current if omitted)
 - `:help` or `:h` or `:?` - Show command help
 
 **Window Naming:**
 - `:assign-name` or `:an` or `:n` - Assign custom name to selected window
+
+**Configuration:**
+- `:set <key> <value>` - Set a config option at runtime
+- `:config` or `:cfg` - Switch to the Config tab
+- `:hotkeys` or `:hk` - Show/manage hotkey bindings
+- `:as` or `:assign-slots` - Assign workspace window slots by screen position
+
+**Mouse:**
+- `:mouse away` or `:ma` - Move mouse cursor away
+- `:mouse show` or `:ms` - Show mouse cursor
+- `:mouse hide` or `:mh` - Hide mouse cursor
 
 #### No-Space Syntax
 
@@ -228,7 +241,8 @@ This vim-style syntax works alongside traditional space-separated commands.
 
 ### Window Display
 
-COFI shows windows in a 5-column format:
+COFI shows windows in a 6-column format:
+- **Slot** - Harpoon slot indicator (digit/letter if assigned, blank otherwise)
 - **Desktop** - [0-9] for desktop number, [S] for sticky windows
 - **Instance** - Application instance name
 - **Title** - Window title (truncated to fit)

--- a/SPEC.md
+++ b/SPEC.md
@@ -1,0 +1,394 @@
+# COFI Specification
+
+Cofi is a keyboard-driven window switcher for X11/Linux with native GTK UI.
+
+## Window List
+
+Cofi displays a list of open windows on the system.
+
+- Show all normal application windows
+- Exclude docks, desktop backgrounds, and cofi's own window
+- Display format: 6 fixed-width columns, monospace font
+  - Harpoon slot indicator (1 char: digit/letter if assigned, blank otherwise)
+  - Desktop indicator: `[0-9]` or `[S]` for sticky
+  - Instance name (20 chars, truncated)
+  - Window title (55 chars, truncated)
+  - Class name (18 chars, truncated)
+  - Window ID (hex)
+- Display order: bottom-up (first entry at bottom, fzf-style)
+- Selection indicator: `>` prefix on selected row
+
+## MRU Ordering
+
+Windows are ordered by most recently used (MRU). The most recently focused window appears first.
+
+- When a window gains focus, it moves to the front of the list
+- When a window closes, it is removed without disrupting order of remaining windows
+
+## Alt-Tab Behavior
+
+When cofi opens, the selection starts on the second entry (index 1) — the previously active window.
+
+- Pressing Enter immediately switches to that previous window, enabling quick Alt-Tab-style toggling
+- No swap of data structures is needed; this is purely about initial selection placement
+
+## Search
+
+Real-time filtering as the user types. Case-insensitive.
+
+### Search Target
+
+The search matches against the full displayed row as the user sees it — desktop indicator, instance name, window title, class name. This enables queries like "2ter" to find terminals on desktop 2, or combining any visible fields.
+
+### Match Stages (in priority order)
+
+1. **Word boundary** — query matches the start of a word
+   - "comm" matches "Commodoro"
+2. **Initials** — each character matches the first letter of consecutive words
+   - "ddl" matches "Daniel Dario Lukic"
+3. **Subsequence** — characters appear in order within the target
+   - "th" matches "Thunderbird"
+4. **Fuzzy** — fallback with variable scoring
+
+### Scoring Adjustments
+
+- Windows on the current desktop receive a scoring bonus
+- Normal windows rank above special windows (docks, dialogs, etc.)
+
+### Behavior
+
+- Results update instantly as the user types
+- Empty query shows all windows in MRU order
+- Selection resets to default position (index 1) when filter changes
+
+## Keyboard Navigation
+
+- **Up/Down** (or **Ctrl+k/j**) — move selection through the window list
+- **Enter** — activate the selected window
+- **Escape** — close cofi without switching
+- **Tab / Shift+Tab** — switch between tabs (Windows, Workspaces, Harpoon, Names)
+- Typing any character starts filtering immediately (no mode switch needed)
+
+## Window Appearance
+
+- Borderless (no title bar or window decorations)
+- Always on top of other windows
+- Skips taskbar and pager
+- Centered on screen
+- Auto-closes when it loses focus (configurable)
+
+## Layout
+
+- Window list (top) — scrollable text view
+- Search entry (bottom) — single-line input
+
+## Window Activation
+
+When the user selects a window and presses Enter:
+
+- Switch to the window's desktop/workspace if different from current
+- Raise and focus the selected window
+- Close cofi
+
+## System Hotkeys
+
+Cofi runs as a daemon and registers global hotkeys via XGrabKey on the X11 root window.
+
+Hotkey bindings are stored in `hotkeys.json` as `{key, command}` pairs. Each binding maps a key combination to a cofi command string.
+
+- Default bindings:
+  - `Mod1+Tab` → `show windows!`
+  - `Mod1+grave` → `show command!`
+  - `Mod1+BackSpace` → `show workspaces!`
+- Hotkey format: `Modifier+KeyName` using X11 names (`XStringToKeysym`)
+  - Modifiers: `Mod1`, `Mod2`, `Mod3`, `Mod4`, `Control`, `Shift`
+- CapsLock/NumLock variants grabbed automatically
+- Retry/Exit dialog on grab failure (e.g. another app owns the key)
+- When cofi is already visible, show-mode hotkeys switch mode inline (no reopen)
+- Pressing a hotkey while visible cancels any pending focus-loss close timer
+
+### Auto-Execute Marker (`!`)
+
+Hotkey command strings support a `!` suffix to control dispatch behavior:
+
+- **With `!`** — command executes immediately. If it needs UI (e.g. overlay dialog), cofi opens automatically. If it doesn't need UI (e.g. `:jw 3`), it runs silently on the active X11 window.
+- **Without `!`** — cofi opens with the command prefilled in the command line, letting the user edit or add arguments before pressing Enter.
+
+Examples:
+- `"show windows!"` — opens cofi in windows mode immediately
+- `"jw 3!"` — jumps to workspace 3 silently, no cofi window
+- `"maw"` — opens cofi with `:maw` prefilled, user types direction + Enter
+
+## Single Instance
+
+Only one cofi instance runs at a time.
+
+- XGrabKey registration is the natural duplicate-instance guard: a second instance fails to grab hotkeys (BadAccess) and shows a retry/exit dialog
+- No D-Bus or lock files needed
+
+## Daemon vs No-Daemon Mode
+
+- **Daemon (default)** — starts hidden, registers hotkeys, waits. Window shown only on hotkey press.
+- **`--no-daemon`** — shows window immediately, no hotkey registration, quits on close. Useful for WM-shortcut driven workflows.
+
+## Live Window List
+
+The window list updates automatically in real-time:
+
+- New windows appear immediately
+- Closed windows disappear immediately
+- No polling — purely event-driven
+
+## Harpoon Slots
+
+Assign windows to persistent slots for direct access.
+
+- 36 slots available: 0-9 and a-z
+- **Ctrl+[key]** — assign the selected window to that slot
+  - Ctrl+j, Ctrl+k, Ctrl+u are reserved for navigation
+  - Ctrl+Shift+j/k/u overrides the reservation and assigns anyway
+- **Alt+[key]** — activate the window in that slot directly (no exceptions)
+  - Alt+digit behavior depends on `digit_slot_mode` (see below)
+  - Alt+letter always activates global harpoon slots
+- Assignments persist across cofi restarts (stored in config)
+- When an assigned window closes, the slot attempts to reassign to a matching window (by class/title pattern)
+- Harpoon tab shows all current assignments
+- Harpoon indicators visible in the window list
+
+## Workspace Window Slots
+
+When `digit_slot_mode` is set to `per-workspace`, Alt+1-9 activates the Nth window on the current workspace.
+
+- Only visible windows are numbered. Excluded:
+  - Minimized or shaded windows
+  - Occluded windows (>80% covered by a window above in the stacking order)
+  - Cofi's own window
+  - Minimizing or moving windows lets the user control which windows get slots
+- Windows are auto-numbered by screen position: left-to-right, top-to-bottom
+- No manual assignment needed — numbering updates automatically as windows move, resize, minimize, or restore
+- Alt+N is a no-op if the current workspace has fewer than N visible windows
+- Letter-based harpoon slots (Alt+a-z) remain global and unaffected
+
+### Slot Overlay Indicators
+
+After slot assignment, numbered overlays appear briefly centered on each assigned window.
+
+- Overlays are independent X11 windows (visible even after cofi hides)
+- Duration controlled by `slot_overlay_duration_ms` config (default 750, 0 = disabled)
+- Catppuccin-themed: dark background, light text
+
+### Auto-Assignment
+
+Slots auto-assign on every Alt+digit press — no manual step needed. Windows are re-scanned each time, so slots stay correct after moves/resizes.
+
+**Typical workflow**: Alt+Tab (open cofi) → Alt+1 (jump). That's it.
+
+### Manual Assignment
+
+Also available for explicit control:
+
+1. **CLI flag** — `cofi --assign-slots`
+   - For use with external hotkeys (WM, sxhkd, etc.)
+   - Assigns slots on the current workspace and exits silently
+2. **Command mode** — `:as` (or `:assign-slots`)
+   - Also auto-enables per-workspace mode if not already set
+
+### Digit Slot Mode (config)
+
+`digit_slot_mode` controls what Alt+digit does:
+
+- `default` — global harpoon slots (existing behavior)
+- `per-workspace` — workspace-scoped window slots by position
+- `workspaces` — switch to workspace N
+
+Replaces the old `quick_workspace_slots` boolean.
+
+## Custom Window Names
+
+Assign custom names to windows that override the displayed title.
+
+- Display format: "custom_name - original_title"
+- Names persist across cofi restarts (stored in config)
+- When a named window closes, the name attempts to reassign to a matching window
+- Names tab (Ctrl+E to edit, Ctrl+D to delete — works on both active and orphaned entries)
+- Searchable — custom names are included in filter matching
+
+## Command Mode
+
+Vim-style command entry triggered by typing `:` in the search field.
+
+- Mode indicator changes from `>` to `:`
+- Supports compact no-space syntax: `:cw2` is equivalent to `:cw 2`
+- Command history: last 10 commands, navigable with Up/Down
+- Help available via `:help` with paged output
+- Help/config display persists while typing (dismissed on Esc)
+
+### Window Commands
+
+- `:cw [N|dir]` (`:change-workspace`) — move selected window to workspace N or direction (h/j/k/l)
+- `:pw` (`:pull-window`, `:p`) — pull selected window to current workspace
+- `:cl` (`:close-window`, `:c`) — close selected window
+- `:sw` (`:swap-windows`) — swap two windows (positions and sizes)
+- `:maw [N|dir]` (`:move-all-to-workspace`) — move all windows from current workspace to target
+- `:mw` (`:max`, `:maximize-window`) — toggle maximize selected window
+
+### Tiling Commands
+
+- `:tw` or `:t` (`:tile-window`) — tile selected window
+  - Halves: `L`, `R`, `T`, `B` (50%)
+  - Quarters: `l1`, `r1`, `l2`, `r2` (25%)
+  - Two-thirds: `L2`, `R2` (66%)
+  - Three-quarters: `L3`, `R3` (75%)
+  - Center: `c` with optional size
+  - Grid positions: 2x2 or 3x2
+
+### Workspace Commands
+
+- `:jw [N|dir]` (`:jump-workspace`, `:j`) — jump to workspace N or direction (h/j/k/l)
+- `:rw [N]` (`:rename-workspace`) — rename workspace N (current if omitted)
+
+### Window Property Commands
+
+- `:sb` (`:skip-taskbar`) — toggle skip taskbar
+- `:aot` (`:at`, `:always-on-top`) — toggle always on top
+- `:ab` (`:always-below`) — toggle always below
+- `:ew` (`:every-workspace`) — toggle sticky (all desktops)
+
+### Monitor Commands
+
+- `:tm` (`:toggle-monitor`) — move window to next monitor
+- `:hm` (`:horizontal-maximize-window`) — toggle horizontal maximize
+- `:vm` (`:vertical-maximize-window`) — toggle vertical maximize
+
+### Mouse Commands
+
+- `:mouse` (`:m`, `:ma`, `:ms`, `:mh`) — mouse control with subcommand: `away`, `show`, `hide`
+
+### Naming Commands
+
+- `:an` (`:assign-name`, `:n`) — assign custom name to selected window
+
+### Configuration Commands
+
+- `:set <key> <value>` — set a config option at runtime (also accepts `key=value`)
+- `:config` (`:conf`, `:cfg`) — switch to the interactive Config tab
+- `:show` (`:s`) — switch cofi mode: `windows`, `command`, `workspaces`, `harpoon`, `names`, `config`
+
+### Hotkey Management Commands
+
+- `:hotkeys` (`:hotkey`, `:hk`) — show all hotkey bindings
+- `:hotkeys <key> <command>` — bind a hotkey (e.g. `:hotkeys Mod4+1 jw 1`)
+- `:hotkeys <key>` — unbind a hotkey
+- Optional sugar keywords accepted: `list`, `set`, `add`, `del`, `rm`, `remove`
+
+### Slot Commands
+
+- `:as` (`:assign-slots`) — assign workspace window slots by screen position
+
+### Help
+
+- `:help` (`:h`, `:?`) — show command help with paged output
+
+## Tiling
+
+Position and resize the selected window to predefined screen regions.
+
+- Half screen: left, right, top, bottom (50%)
+- Quarters: four corners (25%)
+- Two-thirds: left or right (66%)
+- Three-quarters: left or right (75%)
+- Center: with configurable size
+- Grid positions: 2x2 or 3x2 layout
+- Multi-monitor aware: tiles relative to the window's current monitor
+- Respects work area (excludes panels, docks, taskbars)
+- Respects window size hints (e.g., terminal minimum sizes)
+
+## Workspace Management
+
+View and interact with workspaces via the Workspaces tab.
+
+- List all workspaces with window counts
+- Switch to a workspace by selecting it and pressing Enter
+- Rename workspaces with custom names (persistent)
+- Display as grid (configurable rows via `workspaces_per_row`, 0 = single row)
+- Directional navigation: HJKL and arrow keys in workspace overlays
+
+## Tabs
+
+Six tabs accessible via Tab/Shift+Tab:
+
+1. **Windows** — main window list with search and MRU ordering
+2. **Workspaces** — workspace list and management
+3. **Harpoon** — harpoon slot assignments (Ctrl+E edit, Ctrl+D delete)
+4. **Names** — custom window name assignments (Ctrl+E edit, Ctrl+D delete)
+5. **Config** — all config options (Ctrl+T toggle/cycle, Ctrl+E edit)
+6. **Hotkeys** — hotkey bindings (Ctrl+E edit, Ctrl+D delete)
+
+- Selection state is preserved per tab when switching
+
+## Configuration
+
+Stored in `~/.config/cofi/`:
+
+- `options.json` — application settings
+  - Window position (9 positions: top, center, bottom, corners)
+  - Close on focus loss (on/off)
+  - Workspace grid columns (`workspaces_per_row`, 0 = single row)
+  - Tiling grid columns (2 or 3)
+  - Digit slot mode (`default` / `per-workspace` / `workspaces`)
+  - Slot overlay duration in ms (default 750, 0 = disabled)
+  - Ripple effect (on/off, default on)
+- `hotkeys.json` — system hotkey bindings as `{key, command}` pairs (up to 64)
+  - Managed via `:hotkeys` command or by editing the file directly
+  - Auto-generated with default show-mode bindings on first run
+- `harpoon.json` — harpoon slot assignments with match patterns
+- `names.json` — custom window names
+
+Runtime config changes via `:set <key> <value>` are saved to `options.json` immediately. View current config with `:config`.
+
+## CLI Arguments
+
+- `--align ALIGNMENT` — window position (center, top, bottom, top_left, top_right, left, right, bottom_left, bottom_right)
+- `--no-auto-close` — keep cofi open when it loses focus
+- `--workspaces` — start on the Workspaces tab
+- `--harpoon` — start on the Harpoon tab
+- `--names` — start on the Names tab
+- `--command` — start in command mode
+- `--no-daemon` — show window immediately, quit on close, no hotkey registration
+- `--assign-slots` — assign workspace window slots and exit
+- `--log-level LEVEL` — set log verbosity (trace, debug, info, warn, error, fatal)
+- `--log-file FILE` — write logs to file
+- `--no-log` — disable logging
+- `--version` — show version
+- `--help` — show usage
+- `--help-commands` / `-H` — show command mode help
+
+## Window Highlight (Ripple Effect)
+
+When a window is activated (via Alt-Tab, harpoon, workspace switch), a visual ripple highlights the target window.
+
+- Circle ripple: expanding ring centered on the target window
+- Vsync-locked 60fps via GdkFrameClock + Cairo on a single ARGB popup window
+- 200ms duration with ease-out easing
+- Ring expands from 10% to 30% of screen height, 16px stroke width
+- Color: light blue-white (#f0f0ff), full brightness for 80% then fades out
+- Cancelled immediately on workspace switch to prevent accumulation
+- Configurable: `ripple_enabled` in options.json (default true)
+- Graceful fallback: disabled when no ARGB visual available (no compositor)
+- HiDPI-safe: X11 pixel coordinates for positioning, GDK logical coordinates for drawing
+
+## Compact Command Syntax
+
+Commands support no-space compact form: `:cw2` = `:cw 2`, `:mawk` = `:maw k`.
+
+- Compact forms defined in a data-driven table (COMPACT_FORMS) mapping command names to accepted suffix characters
+- Parser picks the longest matching command name to resolve prefix ambiguity
+- Exact command names are never split: `:maw` stays as command "maw" with no arg, not "m" + "aw"
+- Aliases participate in matching: `:j3` matches alias "j" for "jw", producing "jw" + "3"
+
+## Autostart
+
+Scripts provided for automatic startup:
+
+- **XDG autostart** — `scripts/install-xdg.sh` (installs `.desktop` file to `~/.config/autostart/`)
+- **systemd user service** — `scripts/install-systemd.sh` (enables and starts `cofi.service`)

--- a/SPEC.md
+++ b/SPEC.md
@@ -231,6 +231,7 @@ Vim-style command entry triggered by typing `:` in the search field.
 - `:sw` (`:swap-windows`) — swap two windows (positions and sizes)
 - `:maw [N|dir]` (`:move-all-to-workspace`) — move all windows from current workspace to target
 - `:mw` (`:max`, `:maximize-window`) — toggle maximize selected window
+- `:miw` (`:min`, `:minimize-window`) — toggle minimize (restore if already minimized, closes cofi)
 
 ### Tiling Commands
 

--- a/src/command_definitions.h
+++ b/src/command_definitions.h
@@ -26,6 +26,7 @@ gboolean cmd_always_on_top(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_always_below(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_every_workspace(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_close_window(AppData *app, WindowInfo *window, const char *args);
+gboolean cmd_minimize_window(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_maximize_window(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_horizontal_maximize(AppData *app, WindowInfo *window, const char *args);
 gboolean cmd_vertical_maximize(AppData *app, WindowInfo *window, const char *args);
@@ -128,6 +129,13 @@ static const CommandDef COMMAND_DEFINITIONS[] = {
         .handler = cmd_move_all_to_workspace,
         .description = "Move all windows from current workspace to target workspace",
         .help_format = "maw, move-all-to-workspace [N]"
+    },
+    {
+        .primary = "miw",
+        .aliases = {"min", "minimize-window", NULL},
+        .handler = cmd_minimize_window,
+        .description = "Toggle minimize selected window (restore if already minimized)",
+        .help_format = "miw, min, minimize-window"
     },
     {
         .primary = "mouse",

--- a/src/command_mode.c
+++ b/src/command_mode.c
@@ -678,6 +678,23 @@ gboolean cmd_close_window(AppData *app, WindowInfo *window, const char *args __a
     return TRUE;
 }
 
+gboolean cmd_minimize_window(AppData *app, WindowInfo *window, const char *args __attribute__((unused))) {
+    if (!window) {
+        log_warn("No window selected for minimizing");
+        return FALSE;
+    }
+
+    if (get_window_state(app->display, window->id, "_NET_WM_STATE_HIDDEN")) {
+        activate_window(app->display, window->id);
+        log_info("CMD: Restored minimized window '%s'", window->title);
+    } else {
+        minimize_window(app->display, window->id);
+        log_info("CMD: Minimized window '%s'", window->title);
+    }
+    hide_window(app);
+    return TRUE;
+}
+
 gboolean cmd_maximize_window(AppData *app, WindowInfo *window, const char *args __attribute__((unused))) {
     if (!window) {
         log_warn("No window selected for maximizing");

--- a/src/command_mode.c
+++ b/src/command_mode.c
@@ -13,6 +13,7 @@
 #include "app_data.h"
 #include "hotkey_config.h"
 #include "hotkeys.h"
+#include "dynamic_display.h"
 #include "types.h"
 #include <X11/Xlib.h>
 #include <X11/extensions/Xfixes.h>
@@ -154,7 +155,7 @@ static char *build_help_page_text(AppData *app, char **lines, int total_lines, i
     }
 
     // Help scrollbar: top-down, no inversion needed
-    overlay_scrollbar(rendered, total_lines, visible_lines, start);
+    overlay_scrollbar(rendered, total_lines, visible_lines, start, get_display_columns(app));
 
     return g_string_free(rendered, FALSE);
 }

--- a/src/command_mode.c
+++ b/src/command_mode.c
@@ -12,6 +12,7 @@
 #include "workspace_utils.h"
 #include "app_data.h"
 #include "hotkey_config.h"
+#include "hotkeys.h"
 #include "types.h"
 #include <X11/Xlib.h>
 #include <X11/extensions/Xfixes.h>
@@ -1175,10 +1176,12 @@ gboolean cmd_hotkeys(AppData *app, WindowInfo *window __attribute__((unused)), c
     if (action == 1) {
         add_hotkey_binding(&app->hotkey_config, key, cmd);
         save_hotkey_config(&app->hotkey_config);
+        regrab_hotkeys(app);
         log_info("Hotkey bound: %s → %s", key, cmd);
     } else if (action == 2) {
         if (remove_hotkey_binding(&app->hotkey_config, key)) {
             save_hotkey_config(&app->hotkey_config);
+            regrab_hotkeys(app);
             log_info("Hotkey unbound: %s", key);
         } else {
             log_warn("No hotkey binding for: %s", key);

--- a/src/config.c
+++ b/src/config.c
@@ -483,17 +483,3 @@ void build_config_entries(const CofiConfig *config, ConfigEntry *entries, int *c
     #undef ADD_ENUM
 }
 
-int format_config_display(const CofiConfig *config, char *buf, size_t buf_size) {
-    if (!config || !buf || buf_size == 0) return 0;
-
-    ConfigEntry entries[MAX_CONFIG_ENTRIES];
-    int count = 0;
-    build_config_entries(config, entries, &count);
-
-    int written = 0;
-    for (int i = 0; i < count && written < (int)buf_size - 1; i++) {
-        written += snprintf(buf + written, buf_size - written,
-                            "%-26s %s\n", entries[i].key, entries[i].value);
-    }
-    return written;
-}

--- a/src/config.h
+++ b/src/config.h
@@ -103,9 +103,6 @@ const char* get_next_enum_value(const char *key, const char *current_value);
 // Build the canonical list of all config entries. Single source of truth.
 void build_config_entries(const CofiConfig *config, ConfigEntry *entries, int *count);
 
-// Format all config settings as display text. Returns bytes written.
-int format_config_display(const CofiConfig *config, char *buf, size_t buf_size);
-
 /* Scoring constants from fzy (moved to bottom to maintain compatibility) */
 #define SCORE_MATCH_CONSECUTIVE 16
 #define SCORE_MATCH_SLASH 9

--- a/src/display.c
+++ b/src/display.c
@@ -210,22 +210,60 @@ void generate_scrollbar(int total_items, int visible_items, int scroll_offset, c
     scrollbar[scrollbar_height] = '\0';
 }
 
-// Overlay scrollbar indicators on the last character of each line in text.
+// Overlay scrollbar indicators on the rightmost column of each line in text.
+// Pads short lines with spaces, truncates long lines to target_columns.
 // Modifies text in place. For bottom-up (fzf-style) display, caller should
 // pass flipped offset: (total_items - visible_items) - scroll_offset.
-void overlay_scrollbar(GString *text, int total_items, int visible_items, int scroll_offset) {
-    if (total_items <= visible_items) return;
+void overlay_scrollbar(GString *text, int total_items, int visible_items, int scroll_offset, int target_columns) {
+    if (total_items <= visible_items || target_columns <= 0) return;
+
+    // Find max line length so scrollbar column is at least past all content
+    int max_line_len = 0;
+    const char *scan = text->str;
+    while (*scan) {
+        const char *nl = strchr(scan, '\n');
+        int len = nl ? (int)(nl - scan) : (int)strlen(scan);
+        if (len > max_line_len) max_line_len = len;
+        if (!nl) break;
+        scan = nl + 1;
+    }
+    // Content + 1 space gap + 1 scrollbar char
+    int content_columns = max_line_len + 2;
+    if (content_columns > target_columns) target_columns = content_columns;
 
     char sb[visible_items + 1];
     generate_scrollbar(total_items, visible_items, scroll_offset, sb, visible_items);
 
+    // Rebuild text with each line padded/truncated to target_columns
+    GString *result = g_string_new(NULL);
+    const char *p = text->str;
     int line = 0;
-    for (size_t i = 0; i < text->len && line < visible_items; i++) {
-        if (text->str[i] == '\n' && i > 0) {
-            text->str[i - 1] = sb[line];
-            line++;
+
+    while (*p && line < visible_items) {
+        const char *nl = strchr(p, '\n');
+        int line_len = nl ? (int)(nl - p) : (int)strlen(p);
+
+        if (line_len >= target_columns) {
+            // Truncate to target_columns - 1, then scrollbar
+            g_string_append_len(result, p, target_columns - 1);
+        } else {
+            // Append content, pad with spaces
+            g_string_append_len(result, p, line_len);
+            for (int i = line_len; i < target_columns - 1; i++)
+                g_string_append_c(result, ' ');
         }
+        g_string_append_c(result, sb[line]);
+        g_string_append_c(result, '\n');
+
+        line++;
+        p = nl ? nl + 1 : p + line_len;
     }
+
+    // Append remaining lines unchanged (if any)
+    if (*p) g_string_append(result, p);
+
+    g_string_assign(text, result->str);
+    g_string_free(result, TRUE);
 }
 
 // Format and display windows tab content
@@ -331,7 +369,7 @@ static void format_windows_display(AppData *app, GString *text, int selected_idx
 
     // Overlay scrollbar on last column (flipped offset for bottom-up display)
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 }
 
 // Format and display workspaces tab content
@@ -382,7 +420,7 @@ static void format_workspaces_display(AppData *app, GString *text, int selected_
     }
 
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 }
 
 // Format and display harpoon tab content
@@ -441,7 +479,7 @@ static void format_harpoon_display(AppData *app, GString *text, int selected_idx
     }
 
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 
     // Shortcuts footer
     g_string_append(text, "\n");
@@ -511,7 +549,7 @@ static void format_names_display(AppData *app, GString *text, int selected_idx) 
     }
 
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 
     // Add shortcuts footer
     g_string_append(text, "\n");
@@ -562,7 +600,7 @@ static void format_config_display_tab(AppData *app, GString *text, int selected_
     }
 
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 
     g_string_append(text, "\n");
     g_string_append(text, "Shortcuts: Ctrl+T=Toggle bool  Ctrl+E=Edit value\n");
@@ -612,7 +650,7 @@ static void format_hotkeys_display(AppData *app, GString *text, int selected_idx
     }
 
     int flipped = (total_count > max_lines) ? (total_count - max_lines) - scroll_offset : 0;
-    overlay_scrollbar(text, total_count, max_lines, flipped);
+    overlay_scrollbar(text, total_count, max_lines, flipped, get_display_columns(app));
 
     g_string_append(text, "\n");
     g_string_append(text, "Shortcuts: Ctrl+E=Edit command  Ctrl+D=Delete binding\n");

--- a/src/display.h
+++ b/src/display.h
@@ -21,9 +21,10 @@ int get_max_display_lines_dynamic(AppData *app);
 // Generate text-based scrollbar
 void generate_scrollbar(int total_items, int visible_items, int scroll_offset, char *scrollbar, int scrollbar_height);
 
-// Overlay scrollbar on last char of each line in text (in place).
+// Overlay scrollbar on the rightmost column of each line in text (in place).
+// Pads/truncates each line to target_columns, places scrollbar char at the last position.
 // For bottom-up display, pass flipped offset: (total - visible) - offset.
-void overlay_scrollbar(GString *text, int total_items, int visible_items, int scroll_offset);
+void overlay_scrollbar(GString *text, int total_items, int visible_items, int scroll_offset, int target_columns);
 
 // Activate window using direct X11 calls
 void activate_window(Display *display, Window window_id);

--- a/src/dynamic_display.c
+++ b/src/dynamic_display.c
@@ -337,6 +337,31 @@ gint get_dynamic_max_display_lines(struct AppData *app) {
     return lines;
 }
 
+// Get the number of monospace character columns that fit in the text view
+gint get_display_columns(struct AppData *app) {
+    if (!app || !app->textview) return 80; // fallback
+
+    GtkWidget *tv = app->textview;
+    int widget_width = gtk_widget_get_allocated_width(tv);
+    int left_margin = gtk_text_view_get_left_margin(GTK_TEXT_VIEW(tv));
+    int right_margin = gtk_text_view_get_right_margin(GTK_TEXT_VIEW(tv));
+    int available = widget_width - left_margin - right_margin;
+
+    // Measure monospace char width via Pango
+    PangoContext *context = gtk_widget_get_pango_context(tv);
+    PangoFontDescription *font_desc = pango_context_get_font_description(context);
+    PangoFontMetrics *metrics = pango_context_get_metrics(context, font_desc, NULL);
+    if (!metrics) return 80;
+
+    int char_width = PANGO_PIXELS(pango_font_metrics_get_approximate_char_width(metrics));
+    pango_font_metrics_unref(metrics);
+
+    if (char_width <= 0) return 80;
+
+    int columns = available / char_width;
+    return columns > 0 ? columns : 80;
+}
+
 // Invalidate cache to force recalculation
 void invalidate_display_line_cache(struct AppData *app) {
     (void)app;  // Unused parameter

--- a/src/dynamic_display.h
+++ b/src/dynamic_display.h
@@ -84,6 +84,11 @@ gint get_dynamic_max_display_lines(struct AppData *app);
  */
 void invalidate_display_line_cache(struct AppData *app);
 
+/**
+ * Get the number of monospace character columns that fit in the text view
+ */
+gint get_display_columns(struct AppData *app);
+
 // Utility functions
 
 /**

--- a/src/hotkeys.c
+++ b/src/hotkeys.c
@@ -176,7 +176,14 @@ void setup_hotkeys(AppData *app) {
 
 void cleanup_hotkeys(AppData *app) {
     ungrab_all(app->display);
+    grabbed_count = 0;
     log_debug("Hotkeys unregistered");
+}
+
+void regrab_hotkeys(AppData *app) {
+    cleanup_hotkeys(app);
+    setup_hotkeys(app);
+    log_info("Hotkeys re-grabbed after config change");
 }
 
 typedef struct {

--- a/src/hotkeys.h
+++ b/src/hotkeys.h
@@ -11,6 +11,9 @@ void setup_hotkeys(AppData *app);
 // Unregister all system hotkeys.
 void cleanup_hotkeys(AppData *app);
 
+// Unregister then re-register all hotkeys (call after bind/unbind).
+void regrab_hotkeys(AppData *app);
+
 // Call from handle_x11_event when a KeyPress event is received.
 void handle_hotkey_event(AppData *app, XKeyEvent *event);
 

--- a/src/main.c
+++ b/src/main.c
@@ -488,6 +488,7 @@ static gboolean handle_hotkeys_tab_keys(GdkEventKey *event, AppData *app) {
             HotkeyBinding *binding = &app->filtered_hotkeys[app->selection.hotkeys_index];
             remove_hotkey_binding(&app->hotkey_config, binding->key);
             save_hotkey_config(&app->hotkey_config);
+            regrab_hotkeys(app);
 
             const char *current_filter = gtk_entry_get_text(GTK_ENTRY(app->entry));
             filter_hotkeys(app, current_filter);

--- a/src/utils.c
+++ b/src/utils.c
@@ -2,101 +2,284 @@
 #include <string.h>
 #include <ctype.h>
 #include <stdlib.h>
+#include <stdio.h>
 #include <gdk/gdkkeysyms.h>
 
 // Safe string copy - always null-terminates the destination
 void safe_string_copy(char *dest, const char *src, size_t dest_size) {
     if (!dest || dest_size == 0) return;
-    
+
     if (!src) {
         dest[0] = '\0';
         return;
     }
-    
+
     strncpy(dest, src, dest_size - 1);
     dest[dest_size - 1] = '\0';
 }
 
-// Parse shortcut string like "Super+w", "Ctrl+w", "Ctrl+Shift+w", "Alt+Tab"
-gboolean parse_shortcut(const char *shortcut_str, guint *key, GdkModifierType *mods) {
-    if (!shortcut_str || !key || !mods) return FALSE;
-    
+// --- Modifier alias table ---
+
+typedef struct {
+    const char *name;       // lowercase alias
+    GdkModifierType mask;
+    const char *canonical;  // display name for suggestions
+} ModifierAlias;
+
+static const ModifierAlias modifier_aliases[] = {
+    { "ctrl",      GDK_CONTROL_MASK, "Ctrl"    },
+    { "control",   GDK_CONTROL_MASK, "Control" },
+    { "shift",     GDK_SHIFT_MASK,   "Shift"   },
+    { "alt",       GDK_MOD1_MASK,    "Alt"     },
+    { "mod1",      GDK_MOD1_MASK,    "Mod1"    },
+    { "super",     GDK_SUPER_MASK,   "Super"   },
+    { "mod4",      GDK_SUPER_MASK,   "Mod4"    },
+    { "win",       GDK_SUPER_MASK,   "Win"     },
+    { "windows",   GDK_SUPER_MASK,   "Windows" },
+    { "meta",      GDK_META_MASK,    "Meta"    },
+    { "hyper",     GDK_HYPER_MASK,   "Hyper"   },
+};
+#define NUM_MOD_ALIASES ((int)(sizeof(modifier_aliases) / sizeof(modifier_aliases[0])))
+
+// --- Key alias table ---
+
+typedef struct {
+    const char *name;       // lowercase alias
+    guint keyval;
+    const char *canonical;  // display name for suggestions
+} KeyAlias;
+
+static const KeyAlias key_aliases[] = {
+    { "tab",       GDK_KEY_Tab,       "Tab"       },
+    { "space",     GDK_KEY_space,     "Space"     },
+    { "return",    GDK_KEY_Return,    "Return"    },
+    { "enter",     GDK_KEY_Return,    "Enter"     },
+    { "escape",    GDK_KEY_Escape,    "Escape"    },
+    { "esc",       GDK_KEY_Escape,    "Esc"       },
+    { "backspace", GDK_KEY_BackSpace, "BackSpace" },
+    { "delete",    GDK_KEY_Delete,    "Delete"    },
+    { "del",       GDK_KEY_Delete,    "Del"       },
+    { "insert",    GDK_KEY_Insert,    "Insert"    },
+    { "ins",       GDK_KEY_Insert,    "Ins"       },
+    { "home",      GDK_KEY_Home,      "Home"      },
+    { "end",       GDK_KEY_End,       "End"       },
+    { "pageup",    GDK_KEY_Page_Up,   "PageUp"    },
+    { "page_up",   GDK_KEY_Page_Up,   "Page_Up"   },
+    { "pagedown",  GDK_KEY_Page_Down, "PageDown"  },
+    { "page_down", GDK_KEY_Page_Down, "Page_Down" },
+    { "up",        GDK_KEY_Up,        "Up"        },
+    { "down",      GDK_KEY_Down,      "Down"      },
+    { "left",      GDK_KEY_Left,      "Left"      },
+    { "right",     GDK_KEY_Right,     "Right"     },
+    { "grave",     GDK_KEY_grave,     "grave"     },
+    { "backslash", GDK_KEY_backslash, "backslash" },
+    { "slash",     GDK_KEY_slash,     "slash"     },
+    { "minus",     GDK_KEY_minus,     "minus"     },
+    { "equal",     GDK_KEY_equal,     "equal"     },
+    { "period",    GDK_KEY_period,    "period"    },
+    { "comma",     GDK_KEY_comma,     "comma"     },
+    { "semicolon", GDK_KEY_semicolon, "semicolon" },
+};
+#define NUM_KEY_ALIASES ((int)(sizeof(key_aliases) / sizeof(key_aliases[0])))
+
+// Simple edit-distance (Levenshtein) for short strings, capped at max_dist
+static int edit_distance(const char *a, const char *b) {
+    int la = (int)strlen(a);
+    int lb = (int)strlen(b);
+    if (la > 20 || lb > 20) return 99;
+
+    int dp[21][21];
+    for (int i = 0; i <= la; i++) dp[i][0] = i;
+    for (int j = 0; j <= lb; j++) dp[0][j] = j;
+    for (int i = 1; i <= la; i++) {
+        for (int j = 1; j <= lb; j++) {
+            int cost = (a[i-1] == b[j-1]) ? 0 : 1;
+            dp[i][j] = dp[i-1][j] + 1;               // delete
+            if (dp[i][j-1] + 1 < dp[i][j])
+                dp[i][j] = dp[i][j-1] + 1;            // insert
+            if (dp[i-1][j-1] + cost < dp[i][j])
+                dp[i][j] = dp[i-1][j-1] + cost;       // replace
+        }
+    }
+    return dp[la][lb];
+}
+
+// Find the closest modifier name to `token` (lowercase). Returns canonical name or NULL.
+// On ties, prefer the alias whose length is closest to the token length.
+static const char* suggest_modifier(const char *token) {
+    int best_dist = 3; // max distance to consider a suggestion
+    int best_len_diff = 99;
+    const char *best = NULL;
+    int token_len = (int)strlen(token);
+    for (int i = 0; i < NUM_MOD_ALIASES; i++) {
+        int d = edit_distance(token, modifier_aliases[i].name);
+        int ld = abs((int)strlen(modifier_aliases[i].name) - token_len);
+        if (d < best_dist || (d == best_dist && ld < best_len_diff)) {
+            best_dist = d;
+            best_len_diff = ld;
+            best = modifier_aliases[i].canonical;
+        }
+    }
+    return best;
+}
+
+// Find the closest key name to `token` (lowercase). Returns canonical name or NULL.
+static const char* suggest_key(const char *token) {
+    int best_dist = 3;
+    const char *best = NULL;
+    for (int i = 0; i < NUM_KEY_ALIASES; i++) {
+        int d = edit_distance(token, key_aliases[i].name);
+        if (d < best_dist) {
+            best_dist = d;
+            best = key_aliases[i].canonical;
+        }
+    }
+    return best;
+}
+
+// Try to match a modifier token (lowercase). Returns TRUE and sets mask on match.
+static gboolean match_modifier(const char *token, GdkModifierType *mask) {
+    for (int i = 0; i < NUM_MOD_ALIASES; i++) {
+        if (strcmp(token, modifier_aliases[i].name) == 0) {
+            *mask = modifier_aliases[i].mask;
+            return TRUE;
+        }
+    }
+    return FALSE;
+}
+
+// Try to match a key token (lowercase). Returns TRUE and sets keyval on match.
+static gboolean match_key(const char *token, guint *keyval) {
+    // Single character keys
+    if (strlen(token) == 1) {
+        *keyval = gdk_unicode_to_keyval(token[0]);
+        return TRUE;
+    }
+
+    // Named keys from alias table
+    for (int i = 0; i < NUM_KEY_ALIASES; i++) {
+        if (strcmp(token, key_aliases[i].name) == 0) {
+            *keyval = key_aliases[i].keyval;
+            return TRUE;
+        }
+    }
+
+    // Function keys F1-F12
+    if (token[0] == 'f' && isdigit(token[1])) {
+        int fnum = atoi(token + 1);
+        if (fnum >= 1 && fnum <= 12) {
+            *keyval = GDK_KEY_F1 + (fnum - 1);
+            return TRUE;
+        }
+    }
+
+    return FALSE;
+}
+
+static void set_error(char *error_msg, size_t error_msg_size, const char *fmt, ...) {
+    if (!error_msg || error_msg_size == 0) return;
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(error_msg, error_msg_size, fmt, ap);
+    va_end(ap);
+}
+
+// Core parser with optional error output
+gboolean parse_shortcut_with_error(const char *shortcut_str, guint *key,
+                                   GdkModifierType *mods,
+                                   char *error_msg, size_t error_msg_size) {
+    if (error_msg && error_msg_size > 0) error_msg[0] = '\0';
+
+    if (!shortcut_str || !key || !mods) {
+        set_error(error_msg, error_msg_size, "Invalid arguments to parse_shortcut");
+        return FALSE;
+    }
+
+    if (shortcut_str[0] == '\0') {
+        set_error(error_msg, error_msg_size, "Empty shortcut string");
+        return FALSE;
+    }
+
     *key = 0;
     *mods = 0;
-    
-    // Create a copy of the string to work with
+
+    // Copy and lowercase
     char buffer[256];
     safe_string_copy(buffer, shortcut_str, sizeof(buffer));
-    
-    // Convert to lowercase for easier parsing
     for (char *p = buffer; *p; p++) {
         *p = tolower(*p);
     }
-    
-    // Parse modifiers and key
-    char *token = strtok(buffer, "+");
-    char *last_token = NULL;
-    
-    while (token) {
+
+    // Tokenize by '+'
+    // We need to collect all tokens first (strtok destroys the buffer)
+    char *tokens[16];
+    int token_count = 0;
+    char *tok = strtok(buffer, "+");
+    while (tok && token_count < 16) {
         // Trim whitespace
-        while (*token && isspace(*token)) token++;
-        char *end = token + strlen(token) - 1;
-        while (end > token && isspace(*end)) *end-- = '\0';
-        
-        // Check if this is a modifier
-        if (strcmp(token, "ctrl") == 0 || strcmp(token, "control") == 0) {
-            *mods |= GDK_CONTROL_MASK;
-        } else if (strcmp(token, "shift") == 0) {
-            *mods |= GDK_SHIFT_MASK;
-        } else if (strcmp(token, "alt") == 0 || strcmp(token, "mod1") == 0) {
-            *mods |= GDK_MOD1_MASK;
-        } else if (strcmp(token, "super") == 0 || strcmp(token, "mod4") == 0 || 
-                   strcmp(token, "win") == 0 || strcmp(token, "windows") == 0) {
-            *mods |= GDK_SUPER_MASK;
-        } else {
-            // This should be the key
-            last_token = token;
+        while (*tok && isspace(*tok)) tok++;
+        char *end = tok + strlen(tok) - 1;
+        while (end > tok && isspace(*end)) *end-- = '\0';
+
+        if (*tok) {
+            tokens[token_count++] = tok;
         }
-        
-        token = strtok(NULL, "+");
+        tok = strtok(NULL, "+");
     }
-    
-    // Parse the key
-    if (!last_token) return FALSE;
-    
-    // Handle single character keys
-    if (strlen(last_token) == 1) {
-        *key = gdk_unicode_to_keyval(last_token[0]);
-        return TRUE;
-    }
-    
-    // Handle special keys
-    if (strcmp(last_token, "tab") == 0) {
-        *key = GDK_KEY_Tab;
-    } else if (strcmp(last_token, "space") == 0) {
-        *key = GDK_KEY_space;
-    } else if (strcmp(last_token, "return") == 0 || strcmp(last_token, "enter") == 0) {
-        *key = GDK_KEY_Return;
-    } else if (strcmp(last_token, "escape") == 0 || strcmp(last_token, "esc") == 0) {
-        *key = GDK_KEY_Escape;
-    } else if (strcmp(last_token, "up") == 0) {
-        *key = GDK_KEY_Up;
-    } else if (strcmp(last_token, "down") == 0) {
-        *key = GDK_KEY_Down;
-    } else if (strcmp(last_token, "left") == 0) {
-        *key = GDK_KEY_Left;
-    } else if (strcmp(last_token, "right") == 0) {
-        *key = GDK_KEY_Right;
-    } else if (strncmp(last_token, "f", 1) == 0 && isdigit(last_token[1])) {
-        // Function keys F1-F12
-        int fnum = atoi(last_token + 1);
-        if (fnum >= 1 && fnum <= 12) {
-            *key = GDK_KEY_F1 + (fnum - 1);
-        }
-    } else {
-        // Unknown key
+
+    if (token_count == 0) {
+        set_error(error_msg, error_msg_size, "No key or modifier found in '%s'", shortcut_str);
         return FALSE;
     }
-    
-    return TRUE;
+
+    // Last token is the key; everything before is a modifier
+    char *key_token = tokens[token_count - 1];
+
+    // Parse modifiers (all tokens except the last)
+    for (int i = 0; i < token_count - 1; i++) {
+        GdkModifierType mask;
+        if (match_modifier(tokens[i], &mask)) {
+            *mods |= mask;
+        } else {
+            // Not a known modifier -- try to suggest
+            const char *suggestion = suggest_modifier(tokens[i]);
+            if (suggestion) {
+                set_error(error_msg, error_msg_size,
+                          "Unknown modifier '%s'. Did you mean '%s'?", tokens[i], suggestion);
+            } else {
+                set_error(error_msg, error_msg_size,
+                          "Unknown modifier '%s'. Valid modifiers: Ctrl, Alt, Super, Shift, Meta, Hyper",
+                          tokens[i]);
+            }
+            return FALSE;
+        }
+    }
+
+    // Parse the key
+    if (match_key(key_token, key)) {
+        return TRUE;
+    }
+
+    // Key not recognized -- try to suggest
+    const char *key_suggestion = suggest_key(key_token);
+    // Also check if it's actually a modifier used as a key
+    GdkModifierType dummy;
+    if (match_modifier(key_token, &dummy)) {
+        set_error(error_msg, error_msg_size,
+                  "'%s' is a modifier, not a key. Use it before '+', e.g. '%s+Tab'",
+                  key_token, key_token);
+    } else if (key_suggestion) {
+        set_error(error_msg, error_msg_size,
+                  "Unknown key '%s'. Did you mean '%s'?", key_token, key_suggestion);
+    } else {
+        set_error(error_msg, error_msg_size,
+                  "Unknown key '%s'. Examples: Tab, Space, Return, Escape, BackSpace, a-z, F1-F12",
+                  key_token);
+    }
+    return FALSE;
+}
+
+// Original API preserved for backward compatibility
+gboolean parse_shortcut(const char *shortcut_str, guint *key, GdkModifierType *mods) {
+    return parse_shortcut_with_error(shortcut_str, key, mods, NULL, 0);
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,7 +7,15 @@
 // Safe string copy - always null-terminates the destination
 void safe_string_copy(char *dest, const char *src, size_t dest_size);
 
-// Parse a shortcut string like "Super+w" or "Ctrl+Shift+w" into key and modifiers
+// Parse a shortcut string like "Super+w" or "Ctrl+Shift+w" into key and modifiers.
+// Supports case-insensitive modifiers and common aliases:
+//   Modifiers: ctrl/control, alt/mod1, super/mod4/win/windows, shift
+//   Keys: enter/return, esc/escape, backspace, delete, space, tab, f1-f12
+// If error_msg is non-NULL and parsing fails, writes a helpful diagnostic
+// (e.g. "Did you mean 'Mod1'?") into error_msg (up to error_msg_size bytes).
 gboolean parse_shortcut(const char *shortcut_str, guint *key, GdkModifierType *mods);
+gboolean parse_shortcut_with_error(const char *shortcut_str, guint *key,
+                                   GdkModifierType *mods,
+                                   char *error_msg, size_t error_msg_size);
 
 #endif // UTILS_H

--- a/src/x11_utils.c
+++ b/src/x11_utils.c
@@ -575,6 +575,12 @@ void toggle_maximize_vertical(Display *display, Window window) {
     toggle_window_state(display, window, "_NET_WM_STATE_MAXIMIZED_VERT");
 }
 
+// Minimize (iconify) a window
+void minimize_window(Display *display, Window window) {
+    XIconifyWindow(display, window, DefaultScreen(display));
+    XFlush(display);
+}
+
 // =============================================================================
 // Cached versions - use pre-interned atoms for better performance
 // =============================================================================

--- a/src/x11_utils.h
+++ b/src/x11_utils.h
@@ -56,6 +56,7 @@ gboolean get_window_state(Display *display, Window window, const char *state_ato
 
 // Window management functions
 void close_window(Display *display, Window window);
+void minimize_window(Display *display, Window window);
 void toggle_maximize_window(Display *display, Window window);
 void toggle_maximize_horizontal(Display *display, Window window);
 void toggle_maximize_vertical(Display *display, Window window);

--- a/test/test_command_aliases.c
+++ b/test/test_command_aliases.c
@@ -302,6 +302,9 @@ static void test_commands_without_compact_form(void) {
     check("sb bare", "sb", "sb", "");
     check("pw bare", "pw", "pw", "");
     check("mw bare", "mw", "mw", "");
+    check("miw bare", "miw", "miw", "");
+    check("min bare", "min", "min", "");
+    check("minimize-window bare", "minimize-window", "minimize-window", "");
     check("sw bare", "sw", "sw", "");
     check("ew bare", "ew", "ew", "");
     check("aot bare", "aot", "aot", "");

--- a/test/test_config_set.c
+++ b/test/test_config_set.c
@@ -7,9 +7,6 @@
 int apply_config_setting(CofiConfig *config, const char *key, const char *value,
                          char *err_buf, size_t err_size);
 
-// Format config as display string (for :config command)
-int format_config_display(const CofiConfig *config, char *buf, size_t buf_size);
-
 static int tests_passed = 0;
 static int tests_failed = 0;
 
@@ -153,37 +150,6 @@ static void test_unknown_key(void) {
     ASSERT_ERR("set nonexistent_key value", c, "nonexistent_key", "value");
 }
 
-static void test_format_config(void) {
-    CofiConfig c;
-    init_config_defaults(&c);
-
-    char buf[2048] = {0};
-    int len = format_config_display(&c, buf, sizeof(buf));
-
-    if (len <= 0) {
-        printf("FAIL: format_config_display returned %d\n", len);
-        tests_failed++;
-        return;
-    }
-
-    // Check that all keys appear in output
-    const char *expected_keys[] = {
-        "close_on_focus_loss", "align", "workspaces_per_row", "tile_columns",
-        "digit_slot_mode", "slot_overlay_duration_ms", "ripple_enabled",
-        "hotkey_windows", "hotkey_command", "hotkey_workspaces", NULL
-    };
-
-    for (int i = 0; expected_keys[i]; i++) {
-        if (strstr(buf, expected_keys[i])) {
-            printf("PASS: config display contains '%s'\n", expected_keys[i]);
-            tests_passed++;
-        } else {
-            printf("FAIL: config display missing '%s'\n", expected_keys[i]);
-            tests_failed++;
-        }
-    }
-}
-
 int main(void) {
     printf("Config :set and :config tests\n");
     printf("=============================\n\n");
@@ -193,7 +159,6 @@ int main(void) {
     test_enum_fields();
     test_string_fields();
     test_unknown_key();
-    test_format_config();
 
     printf("\n=====================================\n");
     printf("Results: %d/%d tests passed\n", tests_passed, tests_passed + tests_failed);

--- a/test/test_parse_shortcut.c
+++ b/test/test_parse_shortcut.c
@@ -1,0 +1,258 @@
+#include <stdio.h>
+#include <string.h>
+#include <gdk/gdkkeysyms.h>
+#include "../src/utils.h"
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define ASSERT(cond, msg) do { \
+    tests_run++; \
+    if (cond) { tests_passed++; printf("  PASS: %s\n", msg); } \
+    else { printf("  FAIL: %s (line %d)\n", msg, __LINE__); } \
+} while(0)
+
+// --- Helpers ---
+
+static gboolean parse_ok(const char *str, guint *key, GdkModifierType *mods) {
+    char err[256] = {0};
+    gboolean ok = parse_shortcut_with_error(str, key, mods, err, sizeof(err));
+    if (!ok) printf("    (error: %s)\n", err);
+    return ok;
+}
+
+static gboolean parse_fail(const char *str, char *err, size_t err_size) {
+    guint key;
+    GdkModifierType mods;
+    return !parse_shortcut_with_error(str, &key, &mods, err, err_size);
+}
+
+// --- Test groups ---
+
+static void test_case_insensitive_modifiers(void) {
+    printf("\n--- Case-insensitive modifiers ---\n");
+    guint key; GdkModifierType mods;
+
+    ASSERT(parse_ok("Ctrl+a", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "Ctrl+a (capitalized)");
+    ASSERT(parse_ok("ctrl+a", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "ctrl+a (lowercase)");
+    ASSERT(parse_ok("CTRL+a", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "CTRL+a (uppercase)");
+    ASSERT(parse_ok("cTrL+a", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "cTrL+a (mixed case)");
+
+    ASSERT(parse_ok("Alt+b", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "Alt+b");
+    ASSERT(parse_ok("alt+b", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "alt+b");
+    ASSERT(parse_ok("ALT+b", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "ALT+b");
+
+    ASSERT(parse_ok("Super+c", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "Super+c");
+    ASSERT(parse_ok("super+c", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "super+c");
+    ASSERT(parse_ok("SUPER+c", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "SUPER+c");
+
+    ASSERT(parse_ok("Shift+d", &key, &mods) && (mods & GDK_SHIFT_MASK),
+           "Shift+d");
+    ASSERT(parse_ok("shift+d", &key, &mods) && (mods & GDK_SHIFT_MASK),
+           "shift+d");
+}
+
+static void test_modifier_aliases(void) {
+    printf("\n--- Modifier aliases ---\n");
+    guint key; GdkModifierType mods;
+
+    // Alt == Mod1
+    ASSERT(parse_ok("Alt+x", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "Alt maps to Mod1");
+    ASSERT(parse_ok("Mod1+x", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "Mod1 maps to Mod1");
+    ASSERT(parse_ok("mod1+x", &key, &mods) && (mods & GDK_MOD1_MASK),
+           "mod1 (lowercase) maps to Mod1");
+
+    // Super == Mod4 == Win
+    ASSERT(parse_ok("Super+x", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "Super maps to Super");
+    ASSERT(parse_ok("Mod4+x", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "Mod4 maps to Super");
+    ASSERT(parse_ok("Win+x", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "Win maps to Super");
+    ASSERT(parse_ok("Windows+x", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "Windows maps to Super");
+
+    // Ctrl == Control
+    ASSERT(parse_ok("Ctrl+x", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "Ctrl maps to Control");
+    ASSERT(parse_ok("Control+x", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "Control maps to Control");
+
+    // Meta, Hyper
+    ASSERT(parse_ok("Meta+x", &key, &mods) && (mods & GDK_META_MASK),
+           "Meta modifier");
+    ASSERT(parse_ok("Hyper+x", &key, &mods) && (mods & GDK_HYPER_MASK),
+           "Hyper modifier");
+}
+
+static void test_key_aliases(void) {
+    printf("\n--- Key aliases ---\n");
+    guint key; GdkModifierType mods;
+
+    // Enter == Return
+    ASSERT(parse_ok("Alt+Enter", &key, &mods) && key == GDK_KEY_Return,
+           "Enter maps to Return");
+    ASSERT(parse_ok("Alt+Return", &key, &mods) && key == GDK_KEY_Return,
+           "Return maps to Return");
+    ASSERT(parse_ok("Alt+enter", &key, &mods) && key == GDK_KEY_Return,
+           "enter (lowercase) maps to Return");
+
+    // Esc == Escape
+    ASSERT(parse_ok("Ctrl+Escape", &key, &mods) && key == GDK_KEY_Escape,
+           "Escape key");
+    ASSERT(parse_ok("Ctrl+Esc", &key, &mods) && key == GDK_KEY_Escape,
+           "Esc alias");
+
+    // BackSpace, Delete
+    ASSERT(parse_ok("Alt+BackSpace", &key, &mods) && key == GDK_KEY_BackSpace,
+           "BackSpace key");
+    ASSERT(parse_ok("Alt+backspace", &key, &mods) && key == GDK_KEY_BackSpace,
+           "backspace (lowercase)");
+    ASSERT(parse_ok("Ctrl+Delete", &key, &mods) && key == GDK_KEY_Delete,
+           "Delete key");
+    ASSERT(parse_ok("Ctrl+Del", &key, &mods) && key == GDK_KEY_Delete,
+           "Del alias");
+
+    // Tab, Space
+    ASSERT(parse_ok("Alt+Tab", &key, &mods) && key == GDK_KEY_Tab,
+           "Tab key");
+    ASSERT(parse_ok("Ctrl+Space", &key, &mods) && key == GDK_KEY_space,
+           "Space key");
+
+    // Arrow keys
+    ASSERT(parse_ok("Alt+Up", &key, &mods) && key == GDK_KEY_Up, "Up key");
+    ASSERT(parse_ok("Alt+Down", &key, &mods) && key == GDK_KEY_Down, "Down key");
+    ASSERT(parse_ok("Alt+Left", &key, &mods) && key == GDK_KEY_Left, "Left key");
+    ASSERT(parse_ok("Alt+Right", &key, &mods) && key == GDK_KEY_Right, "Right key");
+
+    // Home, End, Page keys
+    ASSERT(parse_ok("Ctrl+Home", &key, &mods) && key == GDK_KEY_Home, "Home key");
+    ASSERT(parse_ok("Ctrl+End", &key, &mods) && key == GDK_KEY_End, "End key");
+    ASSERT(parse_ok("Ctrl+PageUp", &key, &mods) && key == GDK_KEY_Page_Up, "PageUp key");
+    ASSERT(parse_ok("Ctrl+PageDown", &key, &mods) && key == GDK_KEY_Page_Down, "PageDown key");
+
+    // Function keys
+    ASSERT(parse_ok("F1", &key, &mods) && key == GDK_KEY_F1, "F1 standalone");
+    ASSERT(parse_ok("Ctrl+F5", &key, &mods) && key == GDK_KEY_F5, "Ctrl+F5");
+    ASSERT(parse_ok("Alt+F12", &key, &mods) && key == GDK_KEY_F12, "Alt+F12");
+
+    // Single character keys
+    ASSERT(parse_ok("Ctrl+a", &key, &mods), "Single char 'a'");
+    ASSERT(parse_ok("Alt+z", &key, &mods), "Single char 'z'");
+
+    // Punctuation aliases
+    ASSERT(parse_ok("Alt+grave", &key, &mods) && key == GDK_KEY_grave, "grave key");
+    ASSERT(parse_ok("Alt+backslash", &key, &mods) && key == GDK_KEY_backslash, "backslash key");
+}
+
+static void test_multi_modifier(void) {
+    printf("\n--- Multi-modifier combos ---\n");
+    guint key; GdkModifierType mods;
+
+    ASSERT(parse_ok("Ctrl+Shift+a", &key, &mods) &&
+           (mods & GDK_CONTROL_MASK) && (mods & GDK_SHIFT_MASK),
+           "Ctrl+Shift+a");
+    ASSERT(parse_ok("Ctrl+Alt+Delete", &key, &mods) &&
+           (mods & GDK_CONTROL_MASK) && (mods & GDK_MOD1_MASK) &&
+           key == GDK_KEY_Delete,
+           "Ctrl+Alt+Delete");
+    ASSERT(parse_ok("Super+Shift+F5", &key, &mods) &&
+           (mods & GDK_SUPER_MASK) && (mods & GDK_SHIFT_MASK) &&
+           key == GDK_KEY_F5,
+           "Super+Shift+F5");
+}
+
+static void test_error_messages(void) {
+    printf("\n--- Error messages ---\n");
+    char err[256];
+
+    // Typo in modifier - should suggest
+    ASSERT(parse_fail("Crtl+a", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Ctrl"),
+           "Typo 'Crtl' suggests 'Ctrl'");
+    ASSERT(parse_fail("Atl+a", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Alt"),
+           "Typo 'Atl' suggests 'Alt'");
+    ASSERT(parse_fail("Supr+a", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Super"),
+           "Typo 'Supr' suggests 'Super'");
+    ASSERT(parse_fail("Shfit+a", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Shift"),
+           "Typo 'Shfit' suggests 'Shift'");
+
+    // Unknown key suggests close match
+    ASSERT(parse_fail("Alt+Tba", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Tab"),
+           "Typo 'Tba' suggests 'Tab'");
+    ASSERT(parse_fail("Alt+Esacpe", err, sizeof(err)) && strstr(err, "Did you mean"),
+           "Typo 'Esacpe' suggests something");
+    ASSERT(parse_fail("Alt+Retrn", err, sizeof(err)) && strstr(err, "Did you mean") && strstr(err, "Return"),
+           "Typo 'Retrn' suggests 'Return'");
+
+    // Modifier used as key
+    ASSERT(parse_fail("Ctrl", err, sizeof(err)) && strstr(err, "modifier"),
+           "'Ctrl' alone detected as modifier-not-key");
+
+    // Completely unknown
+    ASSERT(parse_fail("Alt+xyzzy123", err, sizeof(err)) && strstr(err, "Unknown key"),
+           "Totally unknown key gives generic message");
+
+    // Empty string
+    ASSERT(parse_fail("", err, sizeof(err)) && strstr(err, "Empty"),
+           "Empty string gives error");
+
+    // NULL error buffer still works (no crash)
+    {
+        guint key; GdkModifierType mods;
+        gboolean ok = parse_shortcut_with_error("Crtl+a", &key, &mods, NULL, 0);
+        tests_run++;
+        if (!ok) { tests_passed++; printf("  PASS: NULL error buffer doesn't crash\n"); }
+        else { printf("  FAIL: NULL error buffer doesn't crash (line %d)\n", __LINE__); }
+    }
+}
+
+static void test_backward_compat(void) {
+    printf("\n--- Backward compatibility (parse_shortcut) ---\n");
+    guint key; GdkModifierType mods;
+
+    ASSERT(parse_shortcut("Alt+Tab", &key, &mods) && key == GDK_KEY_Tab && (mods & GDK_MOD1_MASK),
+           "parse_shortcut still works for Alt+Tab");
+    ASSERT(parse_shortcut("Super+w", &key, &mods) && (mods & GDK_SUPER_MASK),
+           "parse_shortcut still works for Super+w");
+    ASSERT(!parse_shortcut("Crtl+a", &key, &mods),
+           "parse_shortcut returns FALSE on typo");
+    ASSERT(!parse_shortcut(NULL, &key, &mods),
+           "parse_shortcut handles NULL");
+}
+
+static void test_whitespace_handling(void) {
+    printf("\n--- Whitespace handling ---\n");
+    guint key; GdkModifierType mods;
+
+    ASSERT(parse_ok("Ctrl + a", &key, &mods) && (mods & GDK_CONTROL_MASK),
+           "Ctrl + a (spaces around +)");
+    ASSERT(parse_ok("  Alt  +  Tab  ", &key, &mods) && key == GDK_KEY_Tab,
+           "Extra whitespace handled");
+}
+
+int main(void) {
+    printf("=== parse_shortcut tests ===\n");
+
+    test_case_insensitive_modifiers();
+    test_modifier_aliases();
+    test_key_aliases();
+    test_multi_modifier();
+    test_error_messages();
+    test_backward_compat();
+    test_whitespace_handling();
+
+    printf("\n=== Summary: %d/%d passed ===\n", tests_passed, tests_run);
+    return (tests_passed == tests_run) ? 0 : 1;
+}

--- a/test/test_scrollbar.c
+++ b/test/test_scrollbar.c
@@ -1,0 +1,250 @@
+#include <stdio.h>
+#include <string.h>
+#include <glib.h>
+
+// Copy of generate_scrollbar and overlay_scrollbar from display.c for isolated testing.
+// When the real implementation changes, this test must be updated to match.
+
+void generate_scrollbar(int total_items, int visible_items, int scroll_offset, char *scrollbar, int scrollbar_height) {
+    if (!scrollbar || scrollbar_height <= 0) return;
+    if (total_items <= visible_items) {
+        for (int i = 0; i < scrollbar_height; i++) scrollbar[i] = ' ';
+        scrollbar[scrollbar_height] = '\0';
+        return;
+    }
+    double visible_ratio = (double)visible_items / total_items;
+    double position_ratio = (double)scroll_offset / (total_items - visible_items);
+    int thumb_size = (int)(visible_ratio * scrollbar_height);
+    if (thumb_size < 1) thumb_size = 1;
+    if (thumb_size > scrollbar_height) thumb_size = scrollbar_height;
+    if (scrollbar_height > 1 && thumb_size == scrollbar_height) thumb_size = scrollbar_height - 1;
+    int thumb_start = (int)(position_ratio * (scrollbar_height - thumb_size));
+    if (thumb_start < 0) thumb_start = 0;
+    if (thumb_start + thumb_size > scrollbar_height) thumb_start = scrollbar_height - thumb_size;
+    for (int i = 0; i < scrollbar_height; i++)
+        scrollbar[i] = (i >= thumb_start && i < thumb_start + thumb_size) ? '#' : '.';
+    scrollbar[scrollbar_height] = '\0';
+}
+
+void overlay_scrollbar(GString *text, int total_items, int visible_items, int scroll_offset, int target_columns) {
+    if (total_items <= visible_items || target_columns <= 0) return;
+    // Find max line length so scrollbar column is at least past all content
+    int max_line_len = 0;
+    const char *scan = text->str;
+    while (*scan) {
+        const char *nl = strchr(scan, '\n');
+        int len = nl ? (int)(nl - scan) : (int)strlen(scan);
+        if (len > max_line_len) max_line_len = len;
+        if (!nl) break;
+        scan = nl + 1;
+    }
+    int content_columns = max_line_len + 2;
+    if (content_columns > target_columns) target_columns = content_columns;
+    char sb[visible_items + 1];
+    generate_scrollbar(total_items, visible_items, scroll_offset, sb, visible_items);
+    GString *result = g_string_new(NULL);
+    const char *p = text->str;
+    int line = 0;
+    while (*p && line < visible_items) {
+        const char *nl = strchr(p, '\n');
+        int line_len = nl ? (int)(nl - p) : (int)strlen(p);
+        if (line_len >= target_columns) {
+            g_string_append_len(result, p, target_columns - 1);
+        } else {
+            g_string_append_len(result, p, line_len);
+            for (int i = line_len; i < target_columns - 1; i++)
+                g_string_append_c(result, ' ');
+        }
+        g_string_append_c(result, sb[line]);
+        g_string_append_c(result, '\n');
+        line++;
+        p = nl ? nl + 1 : p + line_len;
+    }
+    if (*p) g_string_append(result, p);
+    g_string_assign(text, result->str);
+    g_string_free(result, TRUE);
+}
+
+static int pass = 0, fail = 0;
+
+#define ASSERT(name, cond) do { \
+    if (cond) { printf("  PASS: %s\n", name); pass++; } \
+    else { printf("  FAIL: %s\n", name); fail++; } \
+} while(0)
+
+// Helper: check that every line in text has scrollbar at column target_columns-1
+static int scrollbar_at_column(const char *text, int target_columns) {
+    const char *p = text;
+    int line = 0;
+    while (*p) {
+        const char *nl = strchr(p, '\n');
+        if (!nl) break;
+        int len = (int)(nl - p);
+        if (len != target_columns) return 0; // line not padded correctly
+        line++;
+        p = nl + 1;
+    }
+    return line > 0;
+}
+
+// Helper: check scrollbar char is one of '#' or '.'
+static int is_scrollbar_char(char c) {
+    return c == '#' || c == '.';
+}
+
+static void test_generate_scrollbar(void) {
+    printf("\n--- generate_scrollbar ---\n");
+
+    char sb[10];
+    generate_scrollbar(20, 5, 0, sb, 5);
+    ASSERT("generates 5-char scrollbar", strlen(sb) == 5);
+    ASSERT("contains # and/or .", sb[0] == '#' || sb[0] == '.');
+
+    generate_scrollbar(5, 5, 0, sb, 5);
+    ASSERT("no scroll needed -> all spaces", sb[0] == ' ' && sb[4] == ' ');
+
+    generate_scrollbar(100, 10, 0, sb, 10);
+    ASSERT("at top: thumb starts at 0", sb[0] == '#');
+
+    generate_scrollbar(100, 10, 90, sb, 10);
+    ASSERT("at bottom: thumb ends at last", sb[9] == '#');
+}
+
+static void test_overlay_pads_short_lines(void) {
+    printf("\n--- overlay: pads short lines ---\n");
+
+    GString *text = g_string_new("abc\ndef\n");
+    // 20 total, 2 visible, scroll at 0, target 10 cols
+    overlay_scrollbar(text, 20, 2, 0, 10);
+
+    // Each line should be exactly 10 chars + \n
+    ASSERT("line 1 padded to 10 chars", text->str[10] == '\n');
+    ASSERT("line 2 padded to 10 chars", text->str[21] == '\n');
+    ASSERT("scrollbar char at col 9 line 1", is_scrollbar_char(text->str[9]));
+    ASSERT("scrollbar char at col 9 line 2", is_scrollbar_char(text->str[20]));
+    ASSERT("padding spaces inserted", text->str[3] == ' ');
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_expands_for_long_lines(void) {
+    printf("\n--- overlay: expands target for long lines ---\n");
+
+    // Lines are 15 and 14 chars, target is 8 — should expand to 17 (max_len + 2)
+    GString *text = g_string_new("abcdefghijklmno\n12345678901234\n");
+    overlay_scrollbar(text, 20, 2, 0, 8);
+
+    // max line is 15, so target becomes 17 (15+2: space gap + scrollbar)
+    ASSERT("line 1 is 17 chars wide", text->str[17] == '\n');
+    ASSERT("scrollbar at col 16", is_scrollbar_char(text->str[16]));
+    ASSERT("space gap before scrollbar", text->str[15] == ' ');
+    ASSERT("content preserved", strncmp(text->str, "abcdefghijklmno", 15) == 0);
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_mixed_lengths(void) {
+    printf("\n--- overlay: mixed line lengths ---\n");
+
+    // Longest line is 26 chars ("this is a longer line here"), target 15 → expands to 28
+    GString *text = g_string_new("short\nthis is a longer line here\nmed\n");
+    overlay_scrollbar(text, 30, 3, 0, 15);
+
+    // max line is 26, so target becomes 28 (26+2)
+    ASSERT("all lines same width", scrollbar_at_column(text->str, 28));
+
+    // Check scrollbar is at column 14 for each line
+    const char *p = text->str;
+    for (int i = 0; i < 3; i++) {
+        const char *nl = strchr(p, '\n');
+        ASSERT("scrollbar char present", nl && is_scrollbar_char(*(nl - 1)));
+        p = nl + 1;
+    }
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_no_scroll_needed(void) {
+    printf("\n--- overlay: no scroll needed ---\n");
+
+    GString *text = g_string_new("line1\nline2\n");
+    char *before = g_strdup(text->str);
+    overlay_scrollbar(text, 2, 5, 0, 10);
+
+    ASSERT("text unchanged when total <= visible", strcmp(text->str, before) == 0);
+
+    g_free(before);
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_empty_text(void) {
+    printf("\n--- overlay: empty text ---\n");
+
+    GString *text = g_string_new("");
+    overlay_scrollbar(text, 10, 5, 0, 10);
+    ASSERT("empty text unchanged", text->len == 0);
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_help_style(void) {
+    printf("\n--- overlay: help-style variable lines ---\n");
+
+    GString *text = g_string_new(
+        "Available commands:\n"
+        "  cw, change-workspace       - Move window\n"
+        "  pw                         - Pull window\n"
+        "  help                       - Show help\n"
+    );
+    overlay_scrollbar(text, 40, 4, 0, 50);
+
+    ASSERT("all help lines same width", scrollbar_at_column(text->str, 50));
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_content_wider_than_target(void) {
+    printf("\n--- overlay: content wider than target expands ---\n");
+
+    // Lines are 15 chars, target is 10 — should expand to 17 (content+2)
+    GString *text = g_string_new("123456789012345\nabcdefghijklmno\n");
+    overlay_scrollbar(text, 20, 2, 0, 10);
+
+    // Should expand to content_width+2 = 17
+    ASSERT("line 1 is 17 chars wide", text->str[17] == '\n');
+    ASSERT("scrollbar at col 16", is_scrollbar_char(text->str[16]));
+    ASSERT("content preserved", strncmp(text->str, "123456789012345", 15) == 0);
+
+    g_string_free(text, TRUE);
+}
+
+static void test_overlay_preserves_content(void) {
+    printf("\n--- overlay: preserves content ---\n");
+
+    GString *text = g_string_new("hello world\ngoodbye now\n");
+    overlay_scrollbar(text, 20, 2, 0, 20);
+
+    ASSERT("line 1 starts with 'hello'", strncmp(text->str, "hello world", 11) == 0);
+    // After "hello world" there should be padding spaces then scrollbar
+    ASSERT("padding after content", text->str[11] == ' ');
+
+    g_string_free(text, TRUE);
+}
+
+int main(void) {
+    printf("Scrollbar overlay tests\n");
+    printf("=======================\n");
+
+    test_generate_scrollbar();
+    test_overlay_pads_short_lines();
+    test_overlay_expands_for_long_lines();
+    test_overlay_mixed_lengths();
+    test_overlay_no_scroll_needed();
+    test_overlay_empty_text();
+    test_overlay_help_style();
+    test_overlay_content_wider_than_target();
+    test_overlay_preserves_content();
+
+    printf("\n=== Summary: %d/%d passed ===\n", pass, pass + fail);
+    return fail > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Closes #27

## Changes

- `src/x11_utils.c/h` — `minimize_window()` using `XIconifyWindow`
- `src/command_mode.c` — `cmd_minimize_window()`: checks `_NET_WM_STATE_HIDDEN`, restores if minimized, iconifies if visible, closes cofi either way
- `src/command_definitions.h` — entry: primary `miw`, aliases `min`, `minimize-window`
- `test/test_command_aliases.c` — 3 new parser pass-through tests
- `README.md`, `SPEC.md` — updated command lists

## Test plan

- [ ] `make test` — all tests pass (562 tests across 11 files)
- [ ] `:miw` on a visible window — window minimizes, cofi closes
- [ ] `:min` on a minimized window (select it in cofi) — window restores, cofi closes
- [ ] `Tab` alone and `Ctrl+Tab` still cycle tabs (not broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)